### PR TITLE
Add Jira API client library and sample

### DIFF
--- a/JiraClient.sln
+++ b/JiraClient.sln
@@ -1,0 +1,30 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33423.123
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JiraClient", "src/JiraClient/JiraClient.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JiraClient.Sample", "src/JiraClient.Sample/JiraClient.Sample.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JiraClient.Tests", "test/JiraClient.Tests/JiraClient.Tests.csproj", "{33333333-3333-3333-3333-333333333333}"
+EndProject
+Global
+  GlobalSection(SolutionConfigurationPlatforms) = preSolution
+    Debug|Any CPU = Debug|Any CPU
+    Release|Any CPU = Release|Any CPU
+  EndGlobalSection
+  GlobalSection(ProjectConfigurationPlatforms) = postSolution
+    {11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {11111111-1111-1111-1111-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {11111111-1111-1111-1111-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
+    {22222222-2222-2222-2222-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {22222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {22222222-2222-2222-2222-222222222222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {22222222-2222-2222-2222-222222222222}.Release|Any CPU.Build.0 = Release|Any CPU
+    {33333333-3333-3333-3333-333333333333}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {33333333-3333-3333-3333-333333333333}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {33333333-3333-3333-3333-333333333333}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {33333333-3333-3333-3333-333333333333}.Release|Any CPU.Build.0 = Release|Any CPU
+  EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# jiraclient
-Chatgpt Codex generated client
+# JiraClient
+
+This repository contains a small HTTP client library for Jira along with a sample console application. The client follows SOLID design principles and exposes an `IJiraClient` interface for consumers.
+
+## Projects
+
+- **JiraClient** – .NET class library that wraps minimal Jira REST API calls.
+- **JiraClient.Sample** – console application demonstrating usage of the client.
+- **JiraClient.Tests** – xUnit test project.
+
+## Jira API Reference
+
+The Jira REST API is documented at [Atlassian's developer site](https://developer.atlassian.com/cloud/jira/platform/rest/v2/intro/). This client only implements the `/rest/api/2/issue/{issueKey}` endpoint as an example but can be extended.
+
+## Configuration
+
+Environment specific configuration files are used:
+
+- `appsettings.Development.json` – points the client at the local Mountebank mock (`http://localhost:4545`).
+- `appsettings.Production.json` – example production URL placeholder.
+
+Both files expose a `Jira:BaseUrl` setting that the library reads via dependency injection.
+
+## Running the Sample
+
+1. **Start the mock Jira service** using [Mountebank](http://www.mbtest.org/):
+   ```bash
+   cd mountebank
+   ./start-mountebank.sh
+   ```
+2. **Run the console app** from Visual Studio or Rider:
+   - Open the solution `JiraClient.sln`.
+   - Set `JiraClient.Sample` as the startup project.
+   - Run the application. It will fetch the issue `TEST-1` from the mock service and print the JSON.
+
+## Azure DevOps Build
+
+An example Azure pipeline is provided in `azure-pipelines.yml`. It restores, builds and runs the unit tests using the .NET 6 SDK.
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,17 @@
+trigger:
+- main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- task: UseDotNet@2
+  inputs:
+    packageType: 'sdk'
+    version: '6.0.x'
+- script: dotnet restore
+  displayName: 'Restore'
+- script: dotnet build --no-restore
+  displayName: 'Build'
+- script: dotnet test --no-build
+  displayName: 'Test'

--- a/mountebank/jira-imposter.json
+++ b/mountebank/jira-imposter.json
@@ -1,0 +1,20 @@
+{
+  "port": 4545,
+  "protocol": "http",
+  "stubs": [
+    {
+      "predicates": [
+        { "equals": { "method": "GET", "path": "/rest/api/2/issue/TEST-1" } }
+      ],
+      "responses": [
+        {
+          "is": {
+            "statusCode": 200,
+            "headers": { "Content-Type": "application/json" },
+            "body": "{\"key\":\"TEST-1\",\"fields\":{}}"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mountebank/start-mountebank.sh
+++ b/mountebank/start-mountebank.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+npx mb start --allowInjection --configfile jira-imposter.json

--- a/src/JiraClient.Sample/JiraClient.Sample.csproj
+++ b/src/JiraClient.Sample/JiraClient.Sample.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../JiraClient/JiraClient.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/JiraClient.Sample/Program.cs
+++ b/src/JiraClient.Sample/Program.cs
@@ -1,0 +1,21 @@
+using JiraClient;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = Host.CreateDefaultBuilder(args)
+    .ConfigureAppConfiguration((hostingContext, config) =>
+    {
+        config.AddJsonFile("appsettings.Development.json", optional: true)
+              .AddJsonFile("appsettings.Production.json", optional: true);
+    })
+    .ConfigureServices((context, services) =>
+    {
+        services.AddJiraClient(context.Configuration);
+    });
+
+var host = builder.Build();
+var client = host.Services.GetRequiredService<IJiraClient>();
+
+var issue = await client.GetIssueAsync("TEST-1");
+Console.WriteLine(issue);

--- a/src/JiraClient.Sample/appsettings.Development.json
+++ b/src/JiraClient.Sample/appsettings.Development.json
@@ -1,0 +1,5 @@
+{
+  "Jira": {
+    "BaseUrl": "http://localhost:4545" 
+  }
+}

--- a/src/JiraClient.Sample/appsettings.Production.json
+++ b/src/JiraClient.Sample/appsettings.Production.json
@@ -1,0 +1,5 @@
+{
+  "Jira": {
+    "BaseUrl": "https://yourproduction.jira.server" 
+  }
+}

--- a/src/JiraClient/IJiraClient.cs
+++ b/src/JiraClient/IJiraClient.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace JiraClient;
+
+public interface IJiraClient
+{
+    Task<string> GetIssueAsync(string issueKey);
+}

--- a/src/JiraClient/JiraClient.csproj
+++ b/src/JiraClient/JiraClient.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/JiraClient/JiraClientImpl.cs
+++ b/src/JiraClient/JiraClientImpl.cs
@@ -1,0 +1,30 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+
+namespace JiraClient;
+
+public class JiraOptions
+{
+    public string BaseUrl { get; set; } = string.Empty;
+}
+
+public class JiraClientImpl : IJiraClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly JiraOptions _options;
+
+    public JiraClientImpl(HttpClient httpClient, IOptions<JiraOptions> options)
+    {
+        _httpClient = httpClient;
+        _options = options.Value;
+        _httpClient.BaseAddress = new System.Uri(_options.BaseUrl);
+    }
+
+    public async Task<string> GetIssueAsync(string issueKey)
+    {
+        var response = await _httpClient.GetAsync($"/rest/api/2/issue/{issueKey}");
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync();
+    }
+}

--- a/src/JiraClient/ServiceCollectionExtensions.cs
+++ b/src/JiraClient/ServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JiraClient;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddJiraClient(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<JiraOptions>(configuration.GetSection("Jira"));
+        services.AddHttpClient<IJiraClient, JiraClientImpl>();
+        return services;
+    }
+}

--- a/test/JiraClient.Tests/JiraClient.Tests.csproj
+++ b/test/JiraClient.Tests/JiraClient.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <ProjectReference Include="../../src/JiraClient/JiraClient.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/JiraClient.Tests/JiraClientTests.cs
+++ b/test/JiraClient.Tests/JiraClientTests.cs
@@ -1,0 +1,34 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using JiraClient;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+public class JiraClientTests
+{
+    private class FakeHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"key\":\"TEST-1\"}")
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    [Fact]
+    public async Task GetIssueAsync_ReturnsContent()
+    {
+        var handler = new FakeHandler();
+        var httpClient = new HttpClient(handler);
+        var options = Options.Create(new JiraOptions { BaseUrl = "http://localhost" });
+        var client = new JiraClientImpl(httpClient, options);
+
+        var result = await client.GetIssueAsync("TEST-1");
+        Assert.Contains("TEST-1", result);
+    }
+}


### PR DESCRIPTION
## Summary
- add SOLID Jira client library and DI helpers
- implement sample console app with environment config
- provide mountebank mock service
- add unit test project and Azure pipeline
- document usage in README

## Testing
- `dotnet test JiraClient.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b0607c920832f9eba6e48b4034d85