### PR TITLE
Add OAuth 2 support with token caching

### DIFF
--- a/src/JiraClient.Sample/appsettings.Development.json
+++ b/src/JiraClient.Sample/appsettings.Development.json
@@ -1,5 +1,11 @@
 {
   "Jira": {
-    "BaseUrl": "http://localhost:4545" 
+    "BaseUrl": "http://localhost:4545",
+    "OAuth": {
+      "TokenUrl": "http://localhost:4545/oauth/token",
+      "ClientId": "sample-client",
+      "ClientSecret": "sample-secret",
+      "RefreshToken": "sample-refresh"
+    }
   }
 }

--- a/src/JiraClient.Sample/appsettings.Production.json
+++ b/src/JiraClient.Sample/appsettings.Production.json
@@ -1,5 +1,11 @@
 {
   "Jira": {
-    "BaseUrl": "https://yourproduction.jira.server" 
+    "BaseUrl": "https://yourproduction.jira.server",
+    "OAuth": {
+      "TokenUrl": "https://yourproduction.jira.server/oauth/token",
+      "ClientId": "set-in-env",
+      "ClientSecret": "set-in-env",
+      "RefreshToken": "set-in-env"
+    }
   }
 }

--- a/src/JiraClient/JiraClientImpl.cs
+++ b/src/JiraClient/JiraClientImpl.cs
@@ -7,6 +7,7 @@ namespace JiraClient;
 public class JiraOptions
 {
     public string BaseUrl { get; set; } = string.Empty;
+    public OAuthOptions OAuth { get; set; } = new();
 }
 
 public class JiraClientImpl : IJiraClient

--- a/src/JiraClient/OAuthHttpMessageHandler.cs
+++ b/src/JiraClient/OAuthHttpMessageHandler.cs
@@ -1,0 +1,21 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace JiraClient;
+
+internal class OAuthHttpMessageHandler : DelegatingHandler
+{
+    private readonly IOAuthTokenProvider _tokenProvider;
+
+    public OAuthHttpMessageHandler(IOAuthTokenProvider tokenProvider)
+    {
+        _tokenProvider = tokenProvider;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var token = await _tokenProvider.GetAccessTokenAsync();
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/JiraClient/OAuthOptions.cs
+++ b/src/JiraClient/OAuthOptions.cs
@@ -1,0 +1,9 @@
+namespace JiraClient;
+
+public class OAuthOptions
+{
+    public string TokenUrl { get; set; } = string.Empty;
+    public string ClientId { get; set; } = string.Empty;
+    public string ClientSecret { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
+}

--- a/src/JiraClient/OAuthTokenProvider.cs
+++ b/src/JiraClient/OAuthTokenProvider.cs
@@ -1,0 +1,55 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+
+namespace JiraClient;
+
+public interface IOAuthTokenProvider
+{
+    Task<string> GetAccessTokenAsync();
+}
+
+internal class OAuthTokenProvider : IOAuthTokenProvider
+{
+    private class TokenResponse
+    {
+        public string access_token { get; set; } = string.Empty;
+        public int expires_in { get; set; }
+    }
+
+    private readonly HttpClient _httpClient;
+    private readonly OAuthOptions _options;
+    private string? _accessToken;
+    private DateTime _expiresAtUtc;
+
+    public OAuthTokenProvider(HttpClient httpClient, IOptions<OAuthOptions> options)
+    {
+        _httpClient = httpClient;
+        _options = options.Value;
+    }
+
+    public async Task<string> GetAccessTokenAsync()
+    {
+        if (_accessToken == null || DateTime.UtcNow >= _expiresAtUtc)
+        {
+            var content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["grant_type"] = "refresh_token",
+                ["refresh_token"] = _options.RefreshToken,
+                ["client_id"] = _options.ClientId,
+                ["client_secret"] = _options.ClientSecret
+            });
+
+            var response = await _httpClient.PostAsync(_options.TokenUrl, content);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync();
+            var token = JsonSerializer.Deserialize<TokenResponse>(json)!;
+            _accessToken = token.access_token;
+            _expiresAtUtc = DateTime.UtcNow.AddSeconds(token.expires_in - 30);
+        }
+
+        return _accessToken!;
+    }
+}

--- a/src/JiraClient/ServiceCollectionExtensions.cs
+++ b/src/JiraClient/ServiceCollectionExtensions.cs
@@ -8,7 +8,11 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddJiraClient(this IServiceCollection services, IConfiguration configuration)
     {
         services.Configure<JiraOptions>(configuration.GetSection("Jira"));
-        services.AddHttpClient<IJiraClient, JiraClientImpl>();
+        services.Configure<OAuthOptions>(configuration.GetSection("Jira:OAuth"));
+        services.AddHttpClient<IOAuthTokenProvider, OAuthTokenProvider>();
+        services.AddTransient<OAuthHttpMessageHandler>();
+        services.AddHttpClient<IJiraClient, JiraClientImpl>()
+                .AddHttpMessageHandler<OAuthHttpMessageHandler>();
         return services;
     }
 }

--- a/test/JiraClient.Tests/JiraClientTests.cs
+++ b/test/JiraClient.Tests/JiraClientTests.cs
@@ -20,6 +20,26 @@ public class JiraClientTests
         }
     }
 
+    private class RecordingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    private class FakeTokenProvider : IOAuthTokenProvider
+    {
+        public Task<string> GetAccessTokenAsync() => Task.FromResult("abc123");
+    }
+
     [Fact]
     public async Task GetIssueAsync_ReturnsContent()
     {
@@ -30,5 +50,22 @@ public class JiraClientTests
 
         var result = await client.GetIssueAsync("TEST-1");
         Assert.Contains("TEST-1", result);
+    }
+
+    [Fact]
+    public async Task AuthorizationHeader_IsAdded()
+    {
+        var recordingHandler = new RecordingHandler();
+        var authHandler = new OAuthHttpMessageHandler(new FakeTokenProvider())
+        {
+            InnerHandler = recordingHandler
+        };
+        var httpClient = new HttpClient(authHandler);
+        var options = Options.Create(new JiraOptions { BaseUrl = "http://localhost" });
+        var client = new JiraClientImpl(httpClient, options);
+
+        await client.GetIssueAsync("TEST-1");
+
+        Assert.Equal("Bearer abc123", recordingHandler.LastRequest!.Headers.Authorization!.ToString());
     }
 }


### PR DESCRIPTION
## Summary
- support Jira OAuth2 authentication
- cache tokens and refresh using refresh tokens when expired
- make OAuth options configurable
- update sample configs
- test authorization header injection

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688b23562274832f9e617edb909e2183