### PR TITLE
Improve Mountebank imposter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ runtime without modifying the JSON files.
    cd mountebank
    ./start-mountebank.sh
    ```
+   The imposter requires an `Authorization` header bearing a token. It also
+   determines the HTTP status code from the requested issue key. Requesting
+   `TEST-200` yields a `200` response, `TEST-404` returns `404`, and so on. The
+   predefined issue `TEST-1` continues to return `200`.
 2. **Run the console app** from Visual Studio or Rider:
    - Open the solution `JiraClient.sln`.
    - Set `JiraClient.Sample` as the startup project.

--- a/mountebank/jira-imposter.json
+++ b/mountebank/jira-imposter.json
@@ -4,7 +4,8 @@
   "stubs": [
     {
       "predicates": [
-        { "equals": { "method": "GET", "path": "/rest/api/2/issue/TEST-1" } }
+        { "equals": { "method": "GET", "path": "/rest/api/2/issue/TEST-1" } },
+        { "matches": { "headers": { "Authorization": "Bearer .*" } } }
       ],
       "responses": [
         {
@@ -13,6 +14,17 @@
             "headers": { "Content-Type": "application/json" },
             "body": "{\"key\":\"TEST-1\",\"fields\":{}}"
           }
+        }
+      ]
+    },
+    {
+      "predicates": [
+        { "matches": { "method": "GET", "path": "/rest/api/2/issue/TEST-(\\d\\d\\d)" } },
+        { "matches": { "headers": { "Authorization": "Bearer .*" } } }
+      ],
+      "responses": [
+        {
+          "inject": "function (req) { var m = req.path.match(/TEST-(\\d\\d\\d)/); var code = parseInt(m[1]); return { statusCode: code, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ key: 'TEST-' + code, fields: {} }) }; }"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- handle Authorization header in the mock Jira imposter
- return HTTP status codes based on the requested issue key
- document new behaviour in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b2db47cf0832facd9c8007b0a36dc