### PR TITLE
Enable dynamic mapping for GitHub and PagerDuty

### DIFF
--- a/src/JiraClient.Sample/GitHubRepo.cs
+++ b/src/JiraClient.Sample/GitHubRepo.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace JiraClient.Sample;
+
+public class GitHubRepo
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("full_name")]
+    public string FullName { get; set; } = string.Empty;
+
+    [JsonPropertyName("visibility")]
+    public string Visibility { get; set; } = string.Empty;
+}

--- a/src/JiraClient.Sample/PagerDutyIncident.cs
+++ b/src/JiraClient.Sample/PagerDutyIncident.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace JiraClient.Sample;
+
+public class PagerDutyIncidentList
+{
+    [JsonPropertyName("incidents")]
+    public List<PagerDutyIncident> Incidents { get; set; } = new();
+}
+
+public class PagerDutyIncident
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = string.Empty;
+
+    [JsonPropertyName("summary")]
+    public string Summary { get; set; } = string.Empty;
+}

--- a/src/JiraClient.Sample/Strategies/GitHubStrategy.cs
+++ b/src/JiraClient.Sample/Strategies/GitHubStrategy.cs
@@ -1,22 +1,32 @@
 using System;
 using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using JiraClient.Mapping;
+using JiraClient.Sample;
 
 namespace JiraClient.Sample.Strategies;
 
 public class GitHubStrategy : IApiClientStrategy
 {
     private readonly HttpClient _httpClient;
+    private readonly DynamicMappingService _mapper;
 
-    public GitHubStrategy(HttpClient httpClient)
+    public GitHubStrategy(HttpClient httpClient, DynamicMappingService mapper)
     {
         _httpClient = httpClient;
+        _mapper = mapper;
     }
 
     public async Task RunAsync()
     {
         var response = await _httpClient.GetAsync("repos/dotnet/runtime");
         response.EnsureSuccessStatusCode();
-        var json = await response.Content.ReadAsStringAsync();
-        Console.WriteLine(json);
+        var repo = await response.Content.ReadFromJsonAsync<GitHubRepo>();
+        if (repo is not null)
+        {
+            var mapped = _mapper.Map<UnifiedIssue>("github", repo);
+            Console.WriteLine(JsonSerializer.Serialize(mapped, new JsonSerializerOptions { WriteIndented = true }));
+        }
     }
 }

--- a/src/JiraClient.Sample/Strategies/PagerDutyStrategy.cs
+++ b/src/JiraClient.Sample/Strategies/PagerDutyStrategy.cs
@@ -1,22 +1,34 @@
 using System;
 using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Linq;
+using JiraClient.Mapping;
+using JiraClient.Sample;
 
 namespace JiraClient.Sample.Strategies;
 
 public class PagerDutyStrategy : IApiClientStrategy
 {
     private readonly HttpClient _httpClient;
+    private readonly DynamicMappingService _mapper;
 
-    public PagerDutyStrategy(HttpClient httpClient)
+    public PagerDutyStrategy(HttpClient httpClient, DynamicMappingService mapper)
     {
         _httpClient = httpClient;
+        _mapper = mapper;
     }
 
     public async Task RunAsync()
     {
         var response = await _httpClient.GetAsync("incidents.json");
         response.EnsureSuccessStatusCode();
-        var json = await response.Content.ReadAsStringAsync();
-        Console.WriteLine(json);
+        var incidentList = await response.Content.ReadFromJsonAsync<PagerDutyIncidentList>();
+        var incident = incidentList?.Incidents.FirstOrDefault();
+        if (incident is not null)
+        {
+            var mapped = _mapper.Map<UnifiedIssue>("pagerduty", incident);
+            Console.WriteLine(JsonSerializer.Serialize(mapped, new JsonSerializerOptions { WriteIndented = true }));
+        }
     }
 }

--- a/src/JiraClient.Sample/appsettings.Development.json
+++ b/src/JiraClient.Sample/appsettings.Development.json
@@ -14,6 +14,18 @@
       "Key": "Key",
       "Summary": "Fields.Summary",
       "Status": "Fields.Status.Name"
+    },
+    "github": {
+      "Id": "Id",
+      "Key": "Name",
+      "Summary": "FullName",
+      "Status": "Visibility"
+    },
+    "pagerduty": {
+      "Id": "Id",
+      "Key": "Id",
+      "Summary": "Summary",
+      "Status": "Status"
     }
   }
 }

--- a/src/JiraClient.Sample/appsettings.Production.json
+++ b/src/JiraClient.Sample/appsettings.Production.json
@@ -14,6 +14,18 @@
       "Key": "Key",
       "Summary": "Fields.Summary",
       "Status": "Fields.Status.Name"
+    },
+    "github": {
+      "Id": "Id",
+      "Key": "Name",
+      "Summary": "FullName",
+      "Status": "Visibility"
+    },
+    "pagerduty": {
+      "Id": "Id",
+      "Key": "Id",
+      "Summary": "Summary",
+      "Status": "Status"
     }
   }
 }


### PR DESCRIPTION
## Summary
- map GitHub and PagerDuty responses to `UnifiedIssue`
- add GitHub and PagerDuty mapping config
- deserialize API responses into strongly typed models

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b90d00028832f8eef218f57d75b62