### PR TITLE
Add README and tests for GitHub and PagerDuty clients

### DIFF
--- a/JiraClient.sln
+++ b/JiraClient.sln
@@ -12,6 +12,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PagerDutyClient", "src/Page
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JiraClient.Tests", "test/JiraClient.Tests/JiraClient.Tests.csproj", "{33333333-3333-3333-3333-333333333333}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitHubClient.Tests", "test/GitHubClient.Tests/GitHubClient.Tests.csproj", "{66666666-6666-6666-6666-666666666666}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PagerDutyClient.Tests", "test/PagerDutyClient.Tests/PagerDutyClient.Tests.csproj", "{77777777-7777-7777-7777-777777777777}"
+EndProject
 Global
   GlobalSection(SolutionConfigurationPlatforms) = preSolution
     Debug|Any CPU = Debug|Any CPU
@@ -38,5 +42,13 @@ Global
     {33333333-3333-3333-3333-333333333333}.Debug|Any CPU.Build.0 = Debug|Any CPU
     {33333333-3333-3333-3333-333333333333}.Release|Any CPU.ActiveCfg = Release|Any CPU
     {33333333-3333-3333-3333-333333333333}.Release|Any CPU.Build.0 = Release|Any CPU
-  EndGlobalSection
+    {66666666-6666-6666-6666-666666666666}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {66666666-6666-6666-6666-666666666666}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {66666666-6666-6666-6666-666666666666}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {66666666-6666-6666-6666-666666666666}.Release|Any CPU.Build.0 = Release|Any CPU
+    {77777777-7777-7777-7777-777777777777}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {77777777-7777-7777-7777-777777777777}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {77777777-7777-7777-7777-777777777777}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {77777777-7777-7777-7777-777777777777}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
 EndGlobal

--- a/src/GitHubClient/README.md
+++ b/src/GitHubClient/README.md
@@ -1,0 +1,22 @@
+# GitHubClient
+
+A minimal wrapper around the GitHub REST API.
+
+## Usage
+
+Register the client with dependency injection:
+
+```csharp
+var services = new ServiceCollection()
+    .AddGitHubClient();
+var provider = services.BuildServiceProvider();
+var client = provider.GetRequiredService<IGitHubClient>();
+```
+
+Fetch repository information with `GetRepoAsync`:
+
+```csharp
+var repo = await client.GetRepoAsync("octocat", "Hello-World");
+```
+
+The client defaults the `BaseAddress` to `https://api.github.com/` and adds a `User-Agent` header if one is not provided.

--- a/src/PagerDutyClient/README.md
+++ b/src/PagerDutyClient/README.md
@@ -1,0 +1,22 @@
+# PagerDutyClient
+
+Client for the PagerDuty status API.
+
+## Usage
+
+Add the client to your service collection:
+
+```csharp
+var services = new ServiceCollection()
+    .AddPagerDutyClient();
+var provider = services.BuildServiceProvider();
+var client = provider.GetRequiredService<IPagerDutyClient>();
+```
+
+Retrieve current incidents with `GetIncidentsAsync`:
+
+```csharp
+var incidents = await client.GetIncidentsAsync();
+```
+
+The HTTP client's base address defaults to `https://status.pagerduty.com/api/v2/` if not set.

--- a/test/GitHubClient.Tests/GitHubClient.Tests.csproj
+++ b/test/GitHubClient.Tests/GitHubClient.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="AutoFixture" Version="4.18.0" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <ProjectReference Include="../../src/GitHubClient/GitHubClient.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/GitHubClient.Tests/GitHubClientTests.cs
+++ b/test/GitHubClient.Tests/GitHubClientTests.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using GitHubClient;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+public class GitHubClientTests
+{
+    private class RecordingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    [Fact]
+    public async Task GetRepoAsync_ReturnsRepo()
+    {
+        // arrange
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+                   .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                   .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+                   {
+                       Content = new StringContent("{\"id\":1,\"name\":\"repo\",\"full_name\":\"octocat/repo\",\"visibility\":\"public\"}")
+                   });
+        var httpClient = new HttpClient(handlerMock.Object);
+        var client = new GitHubClientImpl(httpClient);
+
+        // act
+        var repo = await client.GetRepoAsync("octocat", "repo");
+
+        // assert
+        Assert.Equal("repo", repo!.Name);
+    }
+
+    [Fact]
+    public async Task UserAgent_IsAdded()
+    {
+        // arrange
+        var recordingHandler = new RecordingHandler();
+        var httpClient = new HttpClient(recordingHandler);
+        var client = new GitHubClientImpl(httpClient);
+
+        // act
+        await client.GetRepoAsync("octocat", "repo");
+
+        // assert
+        Assert.Contains("metricsclientsample", recordingHandler.LastRequest!.Headers.UserAgent.ToString());
+    }
+}

--- a/test/PagerDutyClient.Tests/PagerDutyClient.Tests.csproj
+++ b/test/PagerDutyClient.Tests/PagerDutyClient.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="AutoFixture" Version="4.18.0" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <ProjectReference Include="../../src/PagerDutyClient/PagerDutyClient.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/PagerDutyClient.Tests/PagerDutyClientTests.cs
+++ b/test/PagerDutyClient.Tests/PagerDutyClientTests.cs
@@ -1,0 +1,45 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using PagerDutyClient;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+public class PagerDutyClientTests
+{
+    [Fact]
+    public async Task GetIncidentsAsync_ReturnsIncidents()
+    {
+        // arrange
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+                   .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                   .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+                   {
+                       Content = new StringContent("{\"incidents\":[{\"id\":\"1\",\"status\":\"triggered\",\"summary\":\"Test\"}]}")
+                   });
+        var httpClient = new HttpClient(handlerMock.Object);
+        var client = new PagerDutyClientImpl(httpClient);
+
+        // act
+        var list = await client.GetIncidentsAsync();
+
+        // assert
+        Assert.Single(list!.Incidents);
+    }
+
+    [Fact]
+    public void Constructor_SetsDefaultBaseAddress()
+    {
+        // arrange
+        var httpClient = new HttpClient(new HttpClientHandler());
+
+        // act
+        var client = new PagerDutyClientImpl(httpClient);
+
+        // assert
+        Assert.Equal("https://status.pagerduty.com/api/v2/", httpClient.BaseAddress!.ToString());
+    }
+}


### PR DESCRIPTION
## Summary
- document GitHubClient and PagerDutyClient usage
- add xUnit test projects for GitHubClient and PagerDutyClient
- include new test projects in solution

## Testing
- `dotnet test JiraClient.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b9657b244832f8dbdc81a37f264a1