### PR TITLE
Add authentication options for GitHub and PagerDuty clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ configuration section looks like:
 as `Jira__OAuth__ClientId` or `Jira__OAuth__RefreshToken` can be supplied at
 runtime without modifying the JSON files.
 
+For GitHub and PagerDuty, supply `GitHub:PersonalAccessToken` and `PagerDuty:ApiKey`
+in the configuration (or as environment variables `GitHub__PersonalAccessToken`
+and `PagerDuty__ApiKey`) to authenticate requests.
+
 ## Service Mocks
 
 The folder `mountebank` contains an `imposters.json` file describing HTTP mocks

--- a/src/GitHubClient/GitHubClient.csproj
+++ b/src/GitHubClient/GitHubClient.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
   </ItemGroup>

--- a/src/GitHubClient/GitHubOptions.cs
+++ b/src/GitHubClient/GitHubOptions.cs
@@ -1,0 +1,6 @@
+namespace GitHubClient;
+
+public class GitHubOptions
+{
+    public string PersonalAccessToken { get; set; } = string.Empty;
+}

--- a/src/GitHubClient/PatHttpMessageHandler.cs
+++ b/src/GitHubClient/PatHttpMessageHandler.cs
@@ -1,0 +1,24 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Options;
+
+namespace GitHubClient;
+
+internal class PatHttpMessageHandler : DelegatingHandler
+{
+    private readonly GitHubOptions _options;
+
+    public PatHttpMessageHandler(IOptions<GitHubOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(_options.PersonalAccessToken) && request.Headers.Authorization == null)
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("token", _options.PersonalAccessToken);
+        }
+        return base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/GitHubClient/README.md
+++ b/src/GitHubClient/README.md
@@ -8,7 +8,7 @@ Register the client with dependency injection:
 
 ```csharp
 var services = new ServiceCollection()
-    .AddGitHubClient();
+    .AddGitHubClient(configuration);
 var provider = services.BuildServiceProvider();
 var client = provider.GetRequiredService<IGitHubClient>();
 ```
@@ -19,4 +19,4 @@ Fetch repository information with `GetRepoAsync`:
 var repo = await client.GetRepoAsync("octocat", "Hello-World");
 ```
 
-The client defaults the `BaseAddress` to `https://api.github.com/` and adds a `User-Agent` header if one is not provided.
+The client defaults the `BaseAddress` to `https://api.github.com/` and adds a `User-Agent` header if one is not provided.  If a `GitHub:PersonalAccessToken` value is supplied in configuration, an `Authorization` header is automatically added to each request.

--- a/src/GitHubClient/ServiceCollectionExtensions.cs
+++ b/src/GitHubClient/ServiceCollectionExtensions.cs
@@ -1,12 +1,19 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace GitHubClient;
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection AddGitHubClient(this IServiceCollection services)
+    public static IServiceCollection AddGitHubClient(this IServiceCollection services, IConfiguration? configuration = null)
     {
-        services.AddHttpClient<IGitHubClient, GitHubClientImpl>();
+        if (configuration != null)
+        {
+            services.Configure<GitHubOptions>(configuration.GetSection("GitHub"));
+        }
+        services.AddTransient<PatHttpMessageHandler>();
+        services.AddHttpClient<IGitHubClient, GitHubClientImpl>()
+                .AddHttpMessageHandler<PatHttpMessageHandler>();
         return services;
     }
 }

--- a/src/MetricsClientSample/Program.cs
+++ b/src/MetricsClientSample/Program.cs
@@ -21,8 +21,8 @@ var builder = Host.CreateDefaultBuilder(args)
     {
         services.AddJiraClient(context.Configuration);
         services.AddDynamicMapping(context.Configuration);
-        services.AddGitHubClient();
-        services.AddPagerDutyClient();
+        services.AddGitHubClient(context.Configuration);
+        services.AddPagerDutyClient(context.Configuration);
         services.AddTransient<JiraStrategy>();
         services.AddTransient<IApiClientStrategy>(sp =>
         {

--- a/src/MetricsClientSample/appsettings.Development.json
+++ b/src/MetricsClientSample/appsettings.Development.json
@@ -8,6 +8,12 @@
       "RefreshToken": "sample-refresh"
     }
   },
+  "GitHub": {
+    "PersonalAccessToken": ""
+  },
+  "PagerDuty": {
+    "ApiKey": ""
+  },
   "Mappings": {
     "jira": {
       "Id": "Id",

--- a/src/MetricsClientSample/appsettings.Production.json
+++ b/src/MetricsClientSample/appsettings.Production.json
@@ -8,6 +8,12 @@
       "RefreshToken": "set-in-env"
     }
   },
+  "GitHub": {
+    "PersonalAccessToken": "set-in-env"
+  },
+  "PagerDuty": {
+    "ApiKey": "set-in-env"
+  },
   "Mappings": {
     "jira": {
       "Id": "Id",

--- a/src/PagerDutyClient/ApiKeyHttpMessageHandler.cs
+++ b/src/PagerDutyClient/ApiKeyHttpMessageHandler.cs
@@ -1,0 +1,25 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Options;
+
+namespace PagerDutyClient;
+
+internal class ApiKeyHttpMessageHandler : DelegatingHandler
+{
+    private readonly PagerDutyOptions _options;
+
+    public ApiKeyHttpMessageHandler(IOptions<PagerDutyOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(_options.ApiKey) && request.Headers.Authorization == null)
+        {
+            // PagerDuty expects the format "Token token=<apiKey>"
+            request.Headers.TryAddWithoutValidation("Authorization", $"Token token={_options.ApiKey}");
+        }
+        return base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/PagerDutyClient/PagerDutyClient.csproj
+++ b/src/PagerDutyClient/PagerDutyClient.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
   </ItemGroup>

--- a/src/PagerDutyClient/PagerDutyOptions.cs
+++ b/src/PagerDutyClient/PagerDutyOptions.cs
@@ -1,0 +1,6 @@
+namespace PagerDutyClient;
+
+public class PagerDutyOptions
+{
+    public string ApiKey { get; set; } = string.Empty;
+}

--- a/src/PagerDutyClient/README.md
+++ b/src/PagerDutyClient/README.md
@@ -8,7 +8,7 @@ Add the client to your service collection:
 
 ```csharp
 var services = new ServiceCollection()
-    .AddPagerDutyClient();
+    .AddPagerDutyClient(configuration);
 var provider = services.BuildServiceProvider();
 var client = provider.GetRequiredService<IPagerDutyClient>();
 ```
@@ -19,4 +19,4 @@ Retrieve current incidents with `GetIncidentsAsync`:
 var incidents = await client.GetIncidentsAsync();
 ```
 
-The HTTP client's base address defaults to `https://status.pagerduty.com/api/v2/` if not set.
+The HTTP client's base address defaults to `https://status.pagerduty.com/api/v2/` if not set. If a `PagerDuty:ApiKey` is configured, an `Authorization` header is added using the `Token token=` format.

--- a/src/PagerDutyClient/ServiceCollectionExtensions.cs
+++ b/src/PagerDutyClient/ServiceCollectionExtensions.cs
@@ -1,12 +1,19 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace PagerDutyClient;
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection AddPagerDutyClient(this IServiceCollection services)
+    public static IServiceCollection AddPagerDutyClient(this IServiceCollection services, IConfiguration? configuration = null)
     {
-        services.AddHttpClient<IPagerDutyClient, PagerDutyClientImpl>();
+        if (configuration != null)
+        {
+            services.Configure<PagerDutyOptions>(configuration.GetSection("PagerDuty"));
+        }
+        services.AddTransient<ApiKeyHttpMessageHandler>();
+        services.AddHttpClient<IPagerDutyClient, PagerDutyClientImpl>()
+                .AddHttpMessageHandler<ApiKeyHttpMessageHandler>();
         return services;
     }
 }

--- a/test/GitHubClient.Tests/GitHubClientTests.cs
+++ b/test/GitHubClient.Tests/GitHubClientTests.cs
@@ -59,4 +59,20 @@ public class GitHubClientTests
         // assert
         Assert.Contains("metricsclientsample", recordingHandler.LastRequest!.Headers.UserAgent.ToString());
     }
+
+    [Fact]
+    public async Task AuthorizationHeader_IsAdded_WhenPatProvided()
+    {
+        var recordingHandler = new RecordingHandler();
+        var patHandler = new PatHttpMessageHandler(Microsoft.Extensions.Options.Options.Create(new GitHubOptions { PersonalAccessToken = "abc" }))
+        {
+            InnerHandler = recordingHandler
+        };
+        var httpClient = new HttpClient(patHandler);
+        var client = new GitHubClientImpl(httpClient);
+
+        await client.GetRepoAsync("octocat", "repo");
+
+        Assert.Equal("token abc", recordingHandler.LastRequest!.Headers.Authorization!.ToString());
+    }
 }


### PR DESCRIPTION
## Summary
- enable GitHubClient to use a PAT from configuration
- enable PagerDutyClient to use an API key from configuration
- wire configuration into sample app
- document the new options
- add unit tests for authorization headers

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688be4e00cd8832f8fdcd833af9b2651